### PR TITLE
Forms::RadioButton: Always set dirty flag when changing state

### DIFF
--- a/forms/radiobutton.cpp
+++ b/forms/radiobutton.cpp
@@ -45,16 +45,16 @@ sp<Control> RadioButton::copyTo(sp<Control> CopyParent)
 
 void RadioButton::setChecked(bool checked)
 {
-	if (checked && !Checked)
+	if (checked != Checked)
 	{
-		if (group)
+		if (group && checked)
 		{
 			for (auto &c : group->radioButtons)
 			{
 				auto button = c.lock();
 				if (button)
 				{
-					button->Checked = false;
+					button->setChecked(false);
 				}
 			}
 		}


### PR DESCRIPTION
Previously, RadioButton::setChecked would only call
Checkbox::setChecked() when transitioning from unchecked->checked, which
means the dirty state was never reset when selecting another in the
group should reset it back to unchecked.

This was causing radio buttons to appear stuck checked.